### PR TITLE
Changes to make it easier to add a map at the end

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adventuremap",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "devkit": {
     "clientPaths": {
       "adventuremap": "src"

--- a/readme_scripts.md
+++ b/readme_scripts.md
@@ -1,0 +1,71 @@
+Scripts:
+    1. create_empty_map - Creates an empty map based on maps object in map_config, also updates height and width based on number and length of maps, bridge and coming soon. Empty map will be stored in map_empty.
+
+    2. duplicate_map - Stiches map files together, adds spacing for bridges and coming_soon. It will take map_data for each map number from a file in maps folder. If the map file doesn't exist, say map1.json doesn't exist, it will instead take the same values for the milestones at a similar row from the origianl_map.js.
+
+    3. map_config - This has config values like width, height of the map. Comingsoon shows the length of comingsoon and bridge. Maps object is used to define the length of each map and how many times it's repeated.
+
+    When creating a map for placing milestones, the length property for comingsoon and bridge should be 0, and only 1 map of some length and repeat as 1.
+
+Files:
+    1. maps/original_map.js - The js file  that is compied from the already map data in the game,  will be used to populate the map in case a maps json file doesn't exist.
+
+    2. maps/map[1,2,3,4...].json - Files that have a single map element. This is what will be repeated and duplicated by duplicate_map.
+
+    3. maps/map_empty.js - The empty map that is created when create_empty_map is run. It is created according to map_config objects. Duplicate map uses the structure in this file to stitch maps and bridges. 
+
+    4. maps/final_map.js - The final map output from duplicate_map when all map data has been repeated and stiched.
+
+Functions in duplicate_map:
+    1. Duplicate map placing comingsoon on top and then loops through empty_map, going bottom up as it takes each tile data from either the original map or loop_data(which is the single map json files that we create initially after placing milestones on them), numbering them in reverse. 
+
+    Once a particular map repeat is done it will put in a bridge in the tile_config and the map based on the length given in map_config before working on the next set of repeated maps.
+
+    - create_map_group: Creates a single map instance(no repeat) from map[1,2,3,...].json. If it detects an object(Which means it is a milestone) it adds it to tiles array. It runs create_object on all the values in tiles array after they are sorted according to y position and reversed(Since we are traversing downwards) which creates the correct milestone paramenters.
+
+    - create_object: Creates a milestone object by adding properties like node, id(number placement). tags. etc
+
+    - create_orig_map: If a map[1,2,3...].json file is not found, duplicate_map will replace the (length X repeat) no. of rows from orig_data. This works for the entire repeating map as defined in the map_config unlike create_map_group which runs for each iteration of the repeat.
+
+To add a map/s:
+    1. Create tiling using devkithelper scripts.
+
+    2. Replace the tiling in the game for a single map.
+
+    3. Create an empty map of desired length(Probably 20), run create empty map with map_config file looking like:
+
+      "maps": [
+
+        {
+
+          "length": 20,
+
+          "repeat": 1
+
+        }
+
+      ]
+
+      and coming_soon and bridge havig a length of 0
+
+    4. copy the resulting empty_map to map_data in the game, modify src/adventuremap/tile.js with map name as the name of the map images you are placing (a folder in resources/tiles should already be there from step 1). Change the height of the map in src/adventuremap/grid.js.
+
+    5. Turn on edit mode in adventure map and create and place milestones in map editor for a single iteration on the map.
+
+    6. Once it is exported, create a map[number].json in the maps file.
+
+    7. Steps 3-6 will be repeated based on the number of maps to be added. 
+
+    8. Modify the config to how a fully created map should look (with bridge and comingsoon lengths and the correct repeat values)
+
+    9. Copy the original map data to maps/original_map.js
+
+    10. Run duplicate_map script which will give you a final_map
+
+    11. Replace map data in game with final_map
+
+    12. The tile config (To be replaced in src/adventuremap/tile.js -> maps) will be shwn as a console log when script has finished running. You will need to rename the proper folder properties since right now they are generated serially but they can repeat.
+
+    Change the height of the map in src/adventuremap/grid.js.
+
+Inserting a map in between can only be done when we have the map objectss for all the maps above the map in question because placing on the original map can be at different positions irrespective of just the height gap.

--- a/scripts/duplicate_map.js
+++ b/scripts/duplicate_map.js
@@ -62,7 +62,6 @@ var ms_tile, lower_range, width, height,
 
             row = Math.floor(ms_tile / width);
             col = ms_tile % width;
-            console.log(tile_value, j, k, l , row, col, orig_map_data.grid[row])
             map_data.grid[row][col] = orig_map_data.grid[row - row_difference][col];
             tile_value++;
         };

--- a/scripts/duplicate_map.js
+++ b/scripts/duplicate_map.js
@@ -48,6 +48,27 @@ var ms_tile, lower_range, width, height,
       });
     }
   },
+  create_orig_map = function (repeat, length) {
+    var tile_value = 0,
+      row_difference = map_data.height - orig_map_data.height,
+      ms_tile, row, col;
+
+    for (var j = repeat; j-- > 0;) {
+      tile_value = 0;
+      current_tile = current_tile - (length * width);
+      for (var k = length; k-- > 0;) {
+        for (var l = -1; l++ < width - 1;) {
+            ms_tile = tile_value + current_tile;
+
+            row = Math.floor(ms_tile / width);
+            col = ms_tile % width;
+            console.log(tile_value, j, k, l , row, col, orig_map_data.grid[row])
+            map_data.grid[row][col] = orig_map_data.grid[row - row_difference][col];
+            tile_value++;
+        };
+      }
+    }
+  },
   create_object = function (tile) {
     var ms_obj = {
       node: '1',
@@ -87,6 +108,7 @@ current_tile = height * width;
 
 jsio.path.add('../');
 jsio('import scripts.maps.map_empty as map_data');
+jsio('import scripts.maps.original_map as orig_map_data');
 
 tile_config.push({
   range: [0, 4],
@@ -96,13 +118,21 @@ tile_config.push({
 _.each(map_config.maps, function (data, num) {
   var map_name = 'map' + (num + 1),
     map_loc = path.join(process.cwd(), process.argv[2]) + '/' + map_name,
-    file_data = require(map_loc),
-    loop_data = file_data.grid,
-    milestones = {};
+    milestones = {},
+    file_data, loop_data;
 
-  _.times(data.repeat, function () {
-    create_map_group(loop_data, data.length);
-  });
+  try {
+    file_data = require(map_loc);
+    loop_data = file_data.grid;
+
+    _.times(data.repeat, function () {
+      create_map_group(loop_data, data.length);
+    });
+  }
+  catch (e) {
+    console.log(map_name + ' was not found, using original elements')
+    create_orig_map(data.repeat, data.length);
+  }
 
   // For map tile config
   lower_range = Math.floor(current_tile / width);


### PR DESCRIPTION
Changes to be able to add a map at the end of already existing tiles.

If we don't have a map file present in maps folder it will pick that map from the original_map.js file(copy of already existing maps), when it has a map[num].json available in maps folder it will repeat and stitch it