### PR TITLE
Optimization: Load and release necessary tiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adventuremap",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "devkit": {
     "clientPaths": {
       "adventuremap": "src"

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ The map contains a model, your can [read about the model here](model.md).
 
 ### Node Tags
 
-A node can be tagged.  It's possible to define a view for a tag.  When a node has a certain tag and the node is visible, then the view will be instanciated and will be shown on the node.  This feature allows you to show custom items on the map at tagged nodes.
+A node can be tagged.  It's possible to define a view for a tag.  When a node has a certain tag and the node is visible, then the view will be instantiated and will be shown on the node.  This feature allows you to show custom items on the map at tagged nodes.
 
 ## Settings objects
 

--- a/src/views/AdventureMapBackgroundView.js
+++ b/src/views/AdventureMapBackgroundView.js
@@ -35,26 +35,28 @@ exports = Class(AdventureMapLayerView, function (supr) {
     });
     view.update(null, x, y);
     return view;
-  }
+  };
 
   this.release = function (x, y) {
-    pool.releaseView(this._views[y][x]);
-    this._views[y][x] = null;
-  }
+    if(this._views[y] && this._views[y][x]) {
+      pool.releaseView(this._views[y][x]);
+      this._views[y][x] = null;
+    }
+  };
 
   this.create = function (x, y) {
     if (!this._views[y]) {
       this._views[y] = [];
     }
     this._views[y][x] = this.setTile(x, y);
-  }
+  };
 
   this.populateView = function (data) {
     var grid = data.grid;
     var width = this._gridSettings.width;
     var height = this._gridSettings.height;
     var tileWidth = this._tileSettings.tileWidth;
-    var tileHeight = this._tileSettings.tileHeight
+    var tileHeight = this._tileSettings.tileHeight;
     var margin = this._editMode ? 8 : 0;
     var pos = data.pos;
 

--- a/src/views/AdventureMapBackgroundView.js
+++ b/src/views/AdventureMapBackgroundView.js
@@ -1,7 +1,4 @@
-import ui.View as View;
 import ui.ViewPool as ViewPool;
-import ui.ImageView as ImageView;
-import ui.resource.Image as Image;
 
 import .tiles.TileView as TileView;
 import .AdventureMapLayerView;

--- a/src/views/AdventureMapNodesView.js
+++ b/src/views/AdventureMapNodesView.js
@@ -1,6 +1,4 @@
-import ui.View as View;
 import ui.ViewPool as ViewPool;
-import ui.resource.Image as Image;
 
 import .tiles.NodeView as NodeView;
 import .AdventureMapLayerView;

--- a/src/views/AdventureMapPathsView.js
+++ b/src/views/AdventureMapPathsView.js
@@ -1,6 +1,3 @@
-import ui.View as View;
-import ui.resource.Image as Image;
-
 import .tiles.PathView as PathView;
 import .AdventureMapLayerView;
 


### PR DESCRIPTION
 Currently the map loads from bottom to top, so if a high enough point is selected to be loaded, it used to create and release a large number of tiles.

This change only loads and releases the necessary tiles. This leads to faster loads and is definitely better